### PR TITLE
Refine deploy, verify, and gas estimation guidance

### DIFF
--- a/conflux-dev/SKILL.md
+++ b/conflux-dev/SKILL.md
@@ -26,7 +26,7 @@ Docs: [Developer Quickstart](https://doc.confluxnetwork.org/docs/espace/Develope
 
 1. **Config** — Add eSpace networks (RPC + chain ID) to Hardhat/Foundry/Remix.
 2. **Build** — Compile Solidity as usual; no eSpace-specific compiler options.
-3. **Deploy** — Deploy to testnet first; use faucet for testnet CFX: https://efaucet.confluxnetwork.org/ Check the original deployment reference before giving commands or config snippets: [reference-deploy-verify.md](reference-deploy-verify.md).
+3. **Deploy** — Deploy to testnet first; use faucet for testnet CFX: https://efaucet.confluxnetwork.org/ For Foundry deployments on Conflux eSpace, explicitly recommend `--gas-estimate-multiplier 200` on both testnet and mainnet because some opcodes are charged higher gas and the default estimate can be too low. Check the original deployment reference before giving commands or config snippets: [reference-deploy-verify.md](reference-deploy-verify.md).
 4. **Verify** — Use ConfluxScan (Etherscan-compatible). Before giving verification commands or troubleshooting advice, check the original verification reference: [reference-deploy-verify.md](reference-deploy-verify.md).
 5. **Integrate** — Frontend: ethers/viem with eSpace RPC; Scaffold Conflux for full-stack. Wallet: MetaMask + add Conflux eSpace (User Guide). See [reference-apps.md](reference-apps.md).
 

--- a/conflux-dev/SKILL.md
+++ b/conflux-dev/SKILL.md
@@ -26,24 +26,9 @@ Docs: [Developer Quickstart](https://doc.confluxnetwork.org/docs/espace/Develope
 
 1. **Config** — Add eSpace networks (RPC + chain ID) to Hardhat/Foundry/Remix.
 2. **Build** — Compile Solidity as usual; no eSpace-specific compiler options.
-3. **Deploy** — Deploy to testnet first; use faucet for testnet CFX: https://efaucet.confluxnetwork.org/
-4. **Verify** — Use ConfluxScan (Etherscan-compatible). Hardhat: custom chains + `hardhat verify`. Foundry: `forge verify-contract` with `--verifier-url` to ConfluxScan API. See [reference-deploy-verify.md](reference-deploy-verify.md).
+3. **Deploy** — Deploy to testnet first; use faucet for testnet CFX: https://efaucet.confluxnetwork.org/ Check the original deployment reference before giving commands or config snippets: [reference-deploy-verify.md](reference-deploy-verify.md).
+4. **Verify** — Use ConfluxScan (Etherscan-compatible). Before giving verification commands or troubleshooting advice, check the original verification reference: [reference-deploy-verify.md](reference-deploy-verify.md).
 5. **Integrate** — Frontend: ethers/viem with eSpace RPC; Scaffold Conflux for full-stack. Wallet: MetaMask + add Conflux eSpace (User Guide). See [reference-apps.md](reference-apps.md).
-
-## Quick deploy
-
-**Hardhat:** Set `networks.eSpaceTestnet.url` and `chainId: 71` (or mainnet 1030). Run `npx hardhat run scripts/deploy.js --network eSpaceTestnet`.
-
-**Foundry:** `forge create --rpc-url https://evmtestnet.confluxrpc.com src/Contract.sol:Contract --private-key <KEY>`.
-
-**Remix:** Add Conflux eSpace Testnet in MetaMask (chain ID 71, RPC above), then deploy via "Injected Provider".
-
-## Verify on ConfluxScan
-
-- **Hardhat:** Configure `etherscan` with ConfluxScan API URL and run `npx hardhat verify --network <network> <address> [constructor args]`.
-- **Foundry:** `forge verify-contract <address> <ContractName> --verifier-url https://evmapi-testnet.confluxscan.org/api/ --etherscan-api-key any` (do not pass chain ID).
-
-Details and config snippets: [reference-deploy-verify.md](reference-deploy-verify.md).
 
 ## App integration
 

--- a/conflux-dev/reference-deploy-verify.md
+++ b/conflux-dev/reference-deploy-verify.md
@@ -64,11 +64,13 @@ If constructor has no args, omit the trailing arguments.
 # Testnet
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://evmtestnet.confluxrpc.com \
+  --gas-estimate-multiplier 200 \
   --private-key $PRIVATE_KEY
 
 # Mainnet
 forge create src/MyContract.sol:MyContract \
   --rpc-url https://evm.confluxrpc.com \
+  --gas-estimate-multiplier 200 \
   --private-key $PRIVATE_KEY
 ```
 
@@ -107,5 +109,6 @@ Doc: https://doc.confluxnetwork.org/docs/espace/tutorials/deployContract/remix
 - **Bytecode comparison:** When debugging verification, compare like with like. Local artifacts often include creation bytecode, while RPC methods and explorers return deployed runtime bytecode.
 - **`evmVersion` compatibility:** If verification tooling exposes `evmVersion`, omit it unless deployment used a specific non-default EVM version. ConfluxScan may reject `evmversion=default`.
 - **Foundry verify:** Do **not** pass `--chain-id`; ConfluxScan verification ignores it and it can break the request. Use only `--verifier-url` and `--etherscan-api-key`.
+- **Foundry deploy gas estimation:** On Conflux eSpace, some opcodes are charged higher gas, so Foundry's default estimate can be too low on both testnet and mainnet. Explicitly recommend `--gas-estimate-multiplier 200` for deployment and upgrade broadcasts to avoid `VmError(OutOfGas)`.
 
 See [Verify contracts](https://doc.confluxnetwork.org/docs/espace/tutorials/VerifyContracts).

--- a/conflux-dev/reference-deploy-verify.md
+++ b/conflux-dev/reference-deploy-verify.md
@@ -48,6 +48,8 @@ module.exports = {
 
 ### Verify
 
+See [Gotchas](#gotchas) for verification caveats.
+
 ```bash
 npx hardhat verify --network eSpaceTestnet <CONTRACT_ADDRESS> [constructor arg1 arg2 ...]
 ```
@@ -74,6 +76,8 @@ forge create src/MyContract.sol:MyContract \
 
 Do **not** pass `--chain-id`. Use ConfluxScan verifier URL:
 
+See [Gotchas](#gotchas) for verification caveats.
+
 ```bash
 # Testnet
 forge verify-contract <CONTRACT_ADDRESS> MyContract \
@@ -99,5 +103,9 @@ Doc: https://doc.confluxnetwork.org/docs/espace/tutorials/deployContract/remix
 
 ## Gotchas
 
+- **Verification failures:** Verification must use the same compiler version and build settings as deployment. If verification fails, confirm solc version and `optimizer.runs` (or equivalent) match what was used when deploying. Compare against the actual deployment inputs, especially if the repo also contains other framework configs or custom `solc` scripts.
+- **Bytecode comparison:** When debugging verification, compare like with like. Local artifacts often include creation bytecode, while RPC methods and explorers return deployed runtime bytecode.
+- **`evmVersion` compatibility:** If verification tooling exposes `evmVersion`, omit it unless deployment used a specific non-default EVM version. ConfluxScan may reject `evmversion=default`.
 - **Foundry verify:** Do **not** pass `--chain-id`; ConfluxScan verification ignores it and it can break the request. Use only `--verifier-url` and `--etherscan-api-key`.
-- **Verification failures:** Compiler version and optimization settings must match the deployment. If verification fails, confirm solc version and `optimizer.runs` (or equivalent) match what was used when deploying. See [Verify contracts](https://doc.confluxnetwork.org/docs/espace/tutorials/VerifyContracts).
+
+See [Verify contracts](https://doc.confluxnetwork.org/docs/espace/tutorials/VerifyContracts).


### PR DESCRIPTION
## Summary
- simplify conflux-dev skill guidance so deploy and verify defer to the reference doc
- move verification caveats into a dedicated Gotchas section with links from each verify subsection
- clarify verification troubleshooting around matching deployment inputs and ConfluxScan quirks
- explicitly recommend `--gas-estimate-multiplier 200` for Foundry deploy and upgrade broadcasts on Conflux eSpace mainnet and testnet because some opcodes are charged higher gas and default estimates can be too low

Refs #5
Refs #8