### PR TITLE
[codex] add skill list index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidance
+
+This repository contains reusable Codex skills for Conflux-related development workflows. Treat each top-level skill directory as an independently installable skill.
+
+## Skill Scope
+
+- Keep each skill focused on one workflow or closely related family of workflows.
+- Put trigger guidance in the `description` field of `SKILL.md` frontmatter. Make it clear when the skill should be used, including common user phrases or contexts.
+- Keep `SKILL.md` concise enough to load directly. If details grow large, move them into targeted reference files and link to the specific file from `SKILL.md`.
+- Keep `SKILL_LIST.md` as the central index of all skills, including each skill's GitHub URL and install command.
+- When a skill references another skill, mention the skill by name and point readers to `SKILL_LIST.md` from the `Related skills` section instead of relying on relative paths.
+- When a skill has variants by tool, framework, network, or workflow, organize details by variant so an agent can load only the relevant reference.
+- Prefer reusable scripts for deterministic or repetitive work instead of asking future agents to reimplement the same procedure.
+
+## Writing Rules
+
+- Write instructions in direct imperative form.
+- Explain why important constraints exist instead of relying only on rigid wording.
+- Be explicit about safety boundaries. For example, read-only inspection skills should say that they do not use private keys, sign transactions, or send transactions.
+- Do not invent external URLs, RPC endpoints, chain IDs, explorer behavior, or API parameters. Prefer official Conflux documentation or checked reference files.
+- Keep examples realistic and copy-pasteable where useful.
+
+## Review Checklist
+
+Before adding or updating a skill, check:
+
+- The frontmatter includes `name` and a useful `description`.
+- The description is specific enough to trigger for the intended tasks without capturing unrelated work.
+- The `SKILL.md` body states the workflow, scope, safety limits, and related skills where relevant.
+- Large details are moved to `references/` with clear links from `SKILL.md`.
+- `SKILL_LIST.md` includes every skill, with its GitHub URL and install command.
+- Cross-skill references point readers to `SKILL_LIST.md` from the `Related skills` section.
+- Any scripts or assets are documented from `SKILL.md` and have a clear reason to exist.
+- The README and `SKILL_LIST.md` skill lists are updated when a skill is added, renamed, or removed.
+- Examples, commands, RPC URLs, chain IDs, and explorer links are current.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Small collection of reusable Codex skills for Conflux-related development workfl
 ```text
 .
 ├── README.md
+├── SKILL_LIST.md
 ├── conflux-dev/
 │   ├── SKILL.md
 │   ├── reference-apps.md
@@ -27,6 +28,8 @@ Small collection of reusable Codex skills for Conflux-related development workfl
 ```
 
 ## Available skills
+
+See [SKILL_LIST.md](SKILL_LIST.md) for the central list of all skills, GitHub URLs, and install commands.
 
 ### conflux-dev
 

--- a/SKILL_LIST.md
+++ b/SKILL_LIST.md
@@ -1,0 +1,15 @@
+# Skill List
+
+Central index for all skills in this repository. Use this file to find the GitHub URL and install command for any skill mentioned by another skill.
+
+Repository: https://github.com/conflux-fans/conflux-skills
+
+## Skills
+
+| Skill | GitHub URL | Install command | Use when |
+|-------|------------|-----------------|----------|
+| `conflux-dev` | https://github.com/conflux-fans/conflux-skills/tree/main/conflux-dev | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-dev` | Building, deploying, verifying smart contracts, or integrating apps with Conflux eSpace. |
+| `conflux-rust-integration-test` | https://github.com/conflux-fans/conflux-skills/tree/main/conflux-rust-integration-test | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-rust-integration-test` | Creating or updating pytest-based integration tests for `conflux-rust`. |
+| `conflux-docs` | https://github.com/conflux-fans/conflux-skills/tree/main/conflux-docs | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-docs` | Finding official Conflux documentation links for concepts, Core Space/eSpace, RPC, deployment, and developer guides. |
+| `conflux-scan-rpc` | https://github.com/conflux-fans/conflux-skills/tree/main/conflux-scan-rpc | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-scan-rpc` | Running read-only Conflux eSpace RPC and ConfluxScan state inspection. |
+| `conflux-eip-6963-wallet` | https://github.com/conflux-fans/conflux-skills/tree/main/conflux-eip-6963-wallet | `npx skills add https://github.com/conflux-fans/conflux-skills --skill conflux-eip-6963-wallet` | Generating or editing dApp frontend wallet connect code with EIP-6963 multi-wallet discovery. |

--- a/conflux-dev/SKILL.md
+++ b/conflux-dev/SKILL.md
@@ -28,7 +28,7 @@ Docs: [Developer Quickstart](https://doc.confluxnetwork.org/docs/espace/Develope
 2. **Build** — Compile Solidity as usual; no eSpace-specific compiler options.
 3. **Deploy** — Deploy to testnet first; use faucet for testnet CFX: https://efaucet.confluxnetwork.org/ For Foundry deployments on Conflux eSpace, explicitly recommend `--gas-estimate-multiplier 200` on both testnet and mainnet because some opcodes are charged higher gas and the default estimate can be too low. Check the original deployment reference before giving commands or config snippets: [reference-deploy-verify.md](reference-deploy-verify.md).
 4. **Verify** — Use ConfluxScan (Etherscan-compatible). Before giving verification commands or troubleshooting advice, check the original verification reference: [reference-deploy-verify.md](reference-deploy-verify.md).
-5. **Integrate** — Frontend: ethers/viem with eSpace RPC; Scaffold Conflux for full-stack. Wallet: use **eip-6963-wallet-discovery** for connect UI (do not default to `window.ethereum`); MetaMask network setup: [eSpace User Guide](https://doc.confluxnetwork.org/docs/espace/UserGuide). See [reference-apps.md](reference-apps.md).
+5. **Integrate** — Frontend: ethers/viem with eSpace RPC; Scaffold Conflux for full-stack. Wallet: use **conflux-eip-6963-wallet** for connect UI (do not default to `window.ethereum`); MetaMask network setup: [eSpace User Guide](https://doc.confluxnetwork.org/docs/espace/UserGuide). See [reference-apps.md](reference-apps.md).
 
 ## App integration
 
@@ -41,7 +41,7 @@ More: [reference-apps.md](reference-apps.md).
 ## Related skills
 
 - **conflux-docs** — doc links and concepts.
-- **eip-6963-wallet-discovery** — multi-wallet connect via EIP-6963 (not `window.ethereum`).
+- **conflux-eip-6963-wallet** — multi-wallet connect via EIP-6963 (not `window.ethereum`).
 - **conflux-scan-rpc** — read-only tx/balance/receipt analysis.
-- **conflux-send-tx** — send txs (user review required).
-- **conflux-agent-wallet** — generate wallet (no user key).
+
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get any mentioned skill if needed.

--- a/conflux-dev/reference-apps.md
+++ b/conflux-dev/reference-apps.md
@@ -62,9 +62,9 @@ Scaffold Conflux is an adaptation of Scaffold-ETH-2 for Conflux.
 
 ## Wallet integration
 
-**For AI-generated dApp frontends:** use the **eip-6963-wallet-discovery** skill. Models default to legacy `window.ethereum`; EIP-6963 enables multi-wallet discovery (MetaMask, Fluent, Rabby, etc.) with proper provider lifecycle.
+**For AI-generated dApp frontends:** use the **conflux-eip-6963-wallet** skill. Models default to legacy `window.ethereum`; EIP-6963 enables multi-wallet discovery (MetaMask, Fluent, Rabby, etc.) with proper provider lifecycle.
 
-Patterns: see `eip-6963-wallet-discovery/reference-patterns.md` in this repo.
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get the skill if needed. Patterns: see [conflux-eip-6963-wallet/reference-patterns.md](https://github.com/conflux-fans/conflux-skills/blob/main/conflux-eip-6963-wallet/reference-patterns.md).
 
 ### MetaMask network setup
 

--- a/conflux-docs/SKILL.md
+++ b/conflux-docs/SKILL.md
@@ -91,3 +91,5 @@ For more concept links, see [reference.md](reference.md) in this skill.
 
 - **conflux-scan-rpc** — inspect txs, receipts, balances (read-only).
 - **conflux-dev** — deploy, verify contracts, integrate apps.
+
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get any mentioned skill if needed.

--- a/conflux-eip-6963-wallet/SKILL.md
+++ b/conflux-eip-6963-wallet/SKILL.md
@@ -45,3 +45,5 @@ Full React + viem + Conflux eSpace patterns (chain definition, `useEip6963Provid
 
 - **conflux-dev** — eSpace RPC, chain IDs, app integration.
 - **conflux-scan-rpc** — inspect tx / balance / receipt (read-only).
+
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get any mentioned skill if needed.

--- a/conflux-rust-integration-test/SKILL.md
+++ b/conflux-rust-integration-test/SKILL.md
@@ -54,3 +54,9 @@ metadata:
 ### assets/
 - `basic_test_template.py`: Starter template for a new integration test module.
 - `custom_block_example.py`: Minimal custom block example.
+
+## Related skills
+
+No required related skills.
+
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get any mentioned skill if needed.

--- a/conflux-scan-rpc/SKILL.md
+++ b/conflux-scan-rpc/SKILL.md
@@ -103,3 +103,5 @@ Copy-paste patterns and full endpoint table: [api-endpoints.md](api-endpoints.md
 
 - **conflux-docs** — official doc links and concepts.
 - **conflux-dev** — deploy, verify, integrate apps.
+
+Check the [Conflux skill list](https://github.com/conflux-fans/conflux-skills/blob/main/SKILL_LIST.md) to get any mentioned skill if needed.


### PR DESCRIPTION
## Summary

- Add `SKILL_LIST.md` as the central index for Conflux skills, including GitHub URLs and install commands.
- Update repository guidance so cross-skill references point to the central skill list.
- Update related skill sections and references to remove stale `conflux-send-tx` and `conflux-agent-wallet` references and use the current `conflux-eip-6963-wallet` name.

## Validation

- Ran `git diff --check`.
- Verified the skill list covers all five `SKILL.md` files in the repository.
- Searched for stale `send-tx` and `agent-wallet` references; none remain.